### PR TITLE
Fix YAML configurations

### DIFF
--- a/confz/loaders/file_loader.py
+++ b/confz/loaders/file_loader.py
@@ -92,7 +92,7 @@ class FileLoader(Loader):
         file_format: FileFormat,
     ) -> dict:
         if file_format == FileFormat.YAML:
-            file_content = yaml.load(stream, Loader=yaml.BaseLoader)
+            file_content = yaml.load(stream, Loader=yaml.SafeLoader)
         elif file_format == FileFormat.JSON:
             file_content = json.load(stream)
         elif file_format == FileFormat.TOML:


### PR DESCRIPTION
During the migration to Pydantic 2 the YAML 'safeload' strategy has been replaced with `baseload`.

This means that YAML values like `hex`, e.g.: 0x2a will be interpreted as a string instead of HEX and you will need to cast those in your Pydantic models which is no fun, this patch restores the old behaviour which I assume is the intended behaviour.